### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,9 @@ __ https://github.com/mattn/go-shellwords
    :target: https://travis-ci.org/mozillazg/python-shellwords
 .. |Coverage| image:: https://coveralls.io/repos/mozillazg/python-shellwords/badge.png?branch=master
    :target: https://coveralls.io/r/mozillazg/python-shellwords
-.. |PyPI version| image:: https://pypip.in/version/shellwords/badge.png
+.. |PyPI version| image:: https://img.shields.io/pypi/v/shellwords.svg
    :target: https://pypi.python.org/pypi/shellwords
-.. |PyPI downloads| image:: https://pypip.in/download/shellwords/badge.png
+.. |PyPI downloads| image:: https://img.shields.io/pypi/dm/shellwords.svg
    :target: https://pypi.python.org/pypi/shellwords
-.. |Python versions| image:: https://pypip.in/py_versions/shellwords/badge.svg
+.. |Python versions| image:: https://img.shields.io/pypi/pyversions/shellwords.svg
    :target: https://pypi.python.org/pypi/shellwords


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20shellwords))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `shellwords`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.